### PR TITLE
fix(roundcube): enforce hard dependency on nginxproxy

### DIFF
--- a/lib/Provisioner/Recipe/roundcube.pm
+++ b/lib/Provisioner/Recipe/roundcube.pm
@@ -54,12 +54,11 @@ sub deps {
 
 sub template_files {
     my ( $class, @modules ) = @_;
-    my %f = (
+    return (
         'roundcube.config.inc.php.tt' => 'config.inc.php',
         'roundcube.fpm.ini.tt'        => 'fpm.ini',
+        'roundcube.nginx.tt'          => 'webmail_nginx.conf',
     );
-    $f{'roundcube.nginx.tt'} = 'webmail_nginx.conf' if any { $_ eq 'nginxproxy' } @modules;
-    return %f;
 }
 
 sub makefile_vars {
@@ -70,6 +69,10 @@ sub makefile_vars {
 
 sub validate {
     my ( $self, %opts ) = @_;
+
+    die "This recipe requires the nginxproxy recipe to function"
+        unless any { $_ eq 'nginxproxy' } @{ $opts{modules} };
+
     $opts{'des_key'} = 'rcube-' . UUID::uuid();
 
     my $ver = $opts{version};


### PR DESCRIPTION
## What
Add a hard `nginxproxy` dependency to the Roundcube recipe via `validate()`, and remove the now-redundant conditional in `template_files()`.

## Why
Roundcube functionally requires nginx — without `nginxproxy`, the nginx config was silently skipped, leaving Roundcube unreachable with no error signal. The breakage was real but invisible. This surfaces it as a clear `die` at validation time, matching the pattern already established by `matrix.pm` (lines 133–135).

## How
- `validate()` now calls `any { $_ eq 'nginxproxy' } @{$opts{modules}}` and dies with a human-readable message if absent — same check as `matrix.pm`. `List::Util qw{any}` was already imported, no new dependency.
- `template_files()` now returns `roundcube.nginx.tt` unconditionally; the `if any { ... }` guard was only there to compensate for the missing hard dep.

## Testing
No automated test suite. Verified changes match the exact pattern in `matrix.pm`. The only behavior change: a config omitting `nginxproxy` now fails fast at `validate()` instead of silently producing a broken setup.

Closes #2