### PR TITLE
fix: make letsencrypt and mail recipes idempotent on redeploy

### DIFF
--- a/templates/letsencrypt.tt
+++ b/templates/letsencrypt.tt
@@ -19,8 +19,13 @@ chmod 0700 /etc/dehydrated/hooks/[% domain %].sh
 mkdir -p /var/lib/dehydrated/certs; /bin/true
 mkdir -p /etc/dehydrated/certs; /bin/true
 mkdir -p /etc/dehydrated/accounts; /bin/true
-rm -rf /var/lib/dehydrated/accounts
-ln -s /etc/dehydrated/accounts /var/lib/dehydrated/accounts
+# Migrate existing accounts to /etc/dehydrated/accounts before symlinking,
+# so redeploys don't lose LE account credentials and hit rate limits.
+if [ -d /var/lib/dehydrated/accounts ] && [ ! -L /var/lib/dehydrated/accounts ]; then \
+	cp -rn /var/lib/dehydrated/accounts/. /etc/dehydrated/accounts/; /bin/true; \
+	rm -rf /var/lib/dehydrated/accounts; \
+fi
+[ -L /var/lib/dehydrated/accounts ] || ln -s /etc/dehydrated/accounts /var/lib/dehydrated/accounts
 # these might not be here
 cp -r [% install_dir %]/[% domain %]/.letsencrypt/var-certs/* /var/lib/dehydrated/certs/; /bin/true
 cp -r [% install_dir %]/[% domain %]/.letsencrypt/etc-certs/* /etc/dehydrated/certs; /bin/true

--- a/templates/mail.tt
+++ b/templates/mail.tt
@@ -10,7 +10,7 @@ mv TrustedHosts /etc/opendkim
 mv SigningTable /etc/opendkim
 mv KeyTable /etc/opendkim
 mv InternalHosts /etc/opendkim
-mv /etc/opendkim.conf /etc/opendkim.conf.orig
+[ -f /etc/opendkim.conf.orig ] || mv /etc/opendkim.conf /etc/opendkim.conf.orig
 mv opendkim.conf /etc/opendkim.conf
 chown opendkim:opendkim /etc/opendkim.conf
 # Generate the key if it does not exist, otherwise use the one you got.
@@ -22,26 +22,26 @@ sudo chmod 0600 /etc/opendkim/keys/[% domain %]/*
 # Stash a copy in /mail owned by the admin for schlepping.
 cp -r /etc/opendkim/keys /mail/keys
 chown -R [% admin_user %]:[% admin_user %] /mail/keys
-mkdir /var/spool/postfix/opendkim
+mkdir -p /var/spool/postfix/opendkim
 chown opendkim:postfix /var/spool/postfix/opendkim
 chmod 0770 /var/spool/postfix/opendkim
 systemctl restart opendkim
 # opendmarc
 mkdir -p /etc/opendmarc
-mv /etc/opendmarc.conf /etc/opendmarc.conf.orig
+[ -f /etc/opendmarc.conf.orig ] || mv /etc/opendmarc.conf /etc/opendmarc.conf.orig
 mv opendmarc.conf /etc/opendmarc.conf
 mv ignore.hosts /etc/opendmarc
 chown -R opendmarc:opendmarc /etc/opendmarc/
 chown opendmarc:opendmarc /etc/opendmarc.conf
-mkdir /var/spool/postfix/opendmarc
+mkdir -p /var/spool/postfix/opendmarc
 chown opendmarc:postfix /var/spool/postfix/opendmarc
 chmod 0770 /var/spool/postfix/opendmarc
 systemctl restart opendmarc
 # update DNS records IFF we have a dns server locally
 [% script_dir %]/queue_postrun_task [% script_dir %]/install_dkim_records [% domain %] /mail/[% domain %]/default.private
 # dovecot
-# First, remove all the worse-than-useless foo in conf.d
-mv /etc/dovecot/conf.d /etc/dovecot/conf-available
+# First, remove all the worse-than-useless foo in conf.d (only on initial deploy)
+[ -d /etc/dovecot/conf-available ] || mv /etc/dovecot/conf.d /etc/dovecot/conf-available
 mkdir -p /etc/dovecot/conf.d
 mv dovecot.conf /etc/dovecot/conf.d/00-dovecot.conf
 mv dovecot.domain.conf /etc/dovecot/conf.d/10-[% domain %].conf
@@ -157,7 +157,7 @@ postconf -e -- "smtpd_sasl_security_options= noanonymous"
 postconf -e -- "smtpd_sasl_local_domain=$$myhostname"
 postconf -e -- "smtpd_relay_restrictions = permit_mynetworks, permit_sasl_authenticated, reject_unauth_destination"
 # master.cf shenanigans
-mv /etc/postfix/master.cf /etc/postfix/master.cf.orig
+[ -f /etc/postfix/master.cf.orig ] || mv /etc/postfix/master.cf /etc/postfix/master.cf.orig
 mv master.cf /etc/postfix
 chown root:root /etc/postfix/master.cf
 chmod 0600 /etc/postfix/master.cf


### PR DESCRIPTION
## What
Fix 7 non-idempotent operations in `letsencrypt.tt` and `mail.tt` that cause failures or data loss when the provisioner is re-run against an existing system.

## Why
Issue #1 calls out that provisioners need to be safe for shared-environment / existing-system deploys. Two of the most critical problems are explicitly named: `letsencrypt` deleting account credentials and `mail` stomping configs it already owns.

Re-running a provisioner is a normal operation (updating config, adding a domain). These bugs make it actively destructive.

## How
**letsencrypt.tt** — `rm -rf /var/lib/dehydrated/accounts` was unconditional. Replaced with: check if accounts is a real directory (not already a symlink), migrate contents to `/etc/dehydrated/accounts`, then remove and symlink. Idempotent on subsequent runs.

**mail.tt** — Six fixes:
- `mv /etc/opendkim.conf /etc/opendkim.conf.orig` → guarded with `[ -f .orig ] ||` so the original system file is preserved across redeployments, not overwritten with our last provisioned version
- Same guard for `opendmarc.conf` and `postfix/master.cf.orig`
- `mkdir /var/spool/postfix/opendkim` → `mkdir -p` (fails without -p on second run)
- Same for `opendmarc` spool dir
- `mv /etc/dovecot/conf.d /etc/dovecot/conf-available` → guarded so redeploy doesn't nest our managed conf.d inside conf-available

## Testing
No test suite in this project. Changes verified by diff review — all guards follow the same pattern already used in pdns.tt (line 37: `mv ... ; /bin/true` and `mkdir -p`) and matrix.tt (line 21: `if [...]; then \ ... fi` backslash-continuation pattern for multi-line shell in Make recipes).