### PR TITLE
fix: guard destructive ops for safe shared-environment redeploy

### DIFF
--- a/templates/backup.tt
+++ b/templates/backup.tt
@@ -1,3 +1,3 @@
-rm [% install_dir %]/[% domain %]/[% key_file %]
+rm -f [% install_dir %]/[% domain %]/[% key_file %]
 mv rsyncd.conf /root/rsyncd.conf
-echo "command=\"rsync --daemon --server --config=/root/rsyncd.conf .\",no-agent-forwarding,no-port-forwarding,no-pty,no-user-rc,no-X11-forwarding [% pubkey %]" >> /root/.ssh/authorized_keys
+grep -qF "[% pubkey %]" /root/.ssh/authorized_keys 2>/dev/null || echo "command=\"rsync --daemon --server --config=/root/rsyncd.conf .\",no-agent-forwarding,no-port-forwarding,no-pty,no-user-rc,no-X11-forwarding [% pubkey %]" >> /root/.ssh/authorized_keys

--- a/templates/mariadb.tt
+++ b/templates/mariadb.tt
@@ -1,9 +1,9 @@
 mkdir -p /opt/mysql; /bin/true
 mv mariadb.service /opt/mysql
 mv my.cnf /opt/mysql
-ln -s /opt/mysql /opt/mariadb
+[ -L /opt/mariadb ] || ln -s /opt/mysql /opt/mariadb
 # Install global schema for the recipe
-useradd -s /usr/sbin/nologin -d /opt/mariadb mysql 
+id mysql &>/dev/null || useradd -s /usr/sbin/nologin -d /opt/mariadb mysql 
 [% script_dir %]/install_mariadb.sh [% user %] [% version %] [% install_dir %]/[% domain %]/[% dumpfile %]
 # Secure the mysql install
 mv secure_installation.sql /opt/mysql

--- a/templates/pdns.tt
+++ b/templates/pdns.tt
@@ -13,7 +13,7 @@ mv pdns-domain.conf /etc/powerdns/pdns.d/sqlite.conf
 # Run on port 2500 so the recursor can run
 mv pdns-global.conf /etc/powerdns/pdns.d/00-global.conf
 # Make sure additions to recursing actually work
-echo "forward-zones=test.test=192.168.1.1" >> /etc/powerdns/recursor.conf
+grep -qF "forward-zones=test.test=192.168.1.1" /etc/powerdns/recursor.conf 2>/dev/null || echo "forward-zones=test.test=192.168.1.1" >> /etc/powerdns/recursor.conf
 # Configure the recursor to answer for our domain
 mv pdns-recursor-domain.conf /etc/powerdns/recursor.d/[% domain %].conf
 # Set up the API so we can use lexicon
@@ -28,7 +28,7 @@ sqlite3 /var/spool/powerdns/zones.db < /usr/share/pdns-backend-sqlite3/schema/sc
 # TODO do this via lexicon instead
 cp zonefile /var/spool/powerdns/[% domain %]/bind.zone
 zone2sql --gsqlite --zone=zonefile --zone-name=[% domain %] > /var/spool/powerdns/[% domain %]/zone.sql
-sqlite3 /var/spool/powerdns/zones.db < /var/spool/powerdns/[% domain %]/zone.sql
+sqlite3 /var/spool/powerdns/zones.db < /var/spool/powerdns/[% domain %]/zone.sql; /bin/true
 chown -R pdns:pdns /var/spool/powerdns
 chmod -R 0775 /var/spool/powerdns
 # Don't need no bind

--- a/templates/roundcube.tt
+++ b/templates/roundcube.tt
@@ -6,7 +6,7 @@ install fpm.ini /etc/php/$(PHP_VER)/fpm/pool.d/roundcube-[% domain %].ini
 install config.inc.php [% install_dir %]/webmail.[% domain %]/config/config.inc.php
 systemctl restart php$(PHP_VER)-fpm
 # Initialize the roundcube database, because autocreate is beyond them
-sqlite3 [% install_dir %]/webmail.[% domain %]_data/roundcube.db < [% install_dir %]/webmail.[% domain %]/SQL/sqlite.initial.sql
+[ -s '[% install_dir %]/webmail.[% domain %]_data/roundcube.db' ] || sqlite3 [% install_dir %]/webmail.[% domain %]_data/roundcube.db < [% install_dir %]/webmail.[% domain %]/SQL/sqlite.initial.sql
 chown -R www-data:www-data [% install_dir %]/webmail.[% domain %]_data
 chown -R www-data:www-data [% install_dir %]/webmail.[% domain %]
 # Setup the vhost

--- a/templates/tpsgi.tt
+++ b/templates/tpsgi.tt
@@ -1,6 +1,6 @@
 mkdir -p '[% install_dir %]/[% domain %]/www';  /bin/true
 mkdir -p '[% install_dir %]/[% domain %]/run';  /bin/true
-cd '[% install_dir %]/[% domain %]' && git clone --no-checkout https://github.com/Troglodyne-Internet-Widgets/tPSGI.git repo && mv repo/.git .git && rmdir repo
+[ -d '[% install_dir %]/[% domain %]/.git' ] || (cd '[% install_dir %]/[% domain %]' && git clone --no-checkout https://github.com/Troglodyne-Internet-Widgets/tPSGI.git repo && mv repo/.git .git && rmdir repo)
 HOME='[% install_dir %]/[% domain %]' git config --global --add safe.directory '[% install_dir %]/[% domain %]'
 cd '[% install_dir %]/[% domain %]' && HOME='[% install_dir %]/[% domain %]' git reset --hard HEAD
 mv tpsgi.ini '[% install_dir %]/[% domain %]/.tpsgi.ini'
@@ -8,7 +8,7 @@ chown -R [% user %]:[% admin_user %] '[% install_dir %]/[% domain %]'
 chown -R [% user %]:www-data '[% install_dir %]/[% domain %]/www'
 chown -R [% user %]:www-data '[% install_dir %]/[% domain %]/run'
 chmod -R 0755 '[% install_dir %]/[% domain %]'
-ln -s [% install_dir %]/[% domain %]/service/tpsgi.service /usr/lib/systemd/system/[% domain %].service
+[ -L /usr/lib/systemd/system/[% domain %].service ] || ln -s [% install_dir %]/[% domain %]/service/tpsgi.service /usr/lib/systemd/system/[% domain %].service
 # We can't guarantee that perl has installed yet.
 # the PATH shenanigans here ensure we get the *right* perl
 [% script_dir %]/queue_postrun_task "PATH=[% install_dir %]/[% domain %]/bin:$$PATH build_service [% domain %] [% extra_env %]"


### PR DESCRIPTION
## What
Guard unconditional destructive/duplicate operations across five recipes so provisioners survive re-runs on an existing system.

## Why
Issue #1 calls out that most provisioners stomp config on re-deploy. PR #5 covers mail and letsencrypt. This PR covers the remaining five recipes with similar patterns:
- `ln -s`, `useradd`, and `git clone` fail outright if already done
- `sqlite3` DB init fails if tables exist, breaking the make target
- `authorized_keys` and `recursor.conf` accumulate duplicates on every run

## How
- **mariadb**: `[ -L /opt/mariadb ] || ln -s ...` and `id mysql &>/dev/null || useradd ...`
- **tpsgi**: guard git clone on `.git` existence; guard systemd service symlink with `[ -L ... ]`
- **roundcube**: `[ -s roundcube.db ] || sqlite3 ... < sqlite.initial.sql` (skip if DB non-empty)
- **backup**: `rm -f` for key file; `grep -qF pubkey authorized_keys || echo ...` to prevent duplicate SSH entries
- **pdns**: `grep -qF ... || echo forward-zones` for recursor; `; /bin/true` on zone SQL import

All guards follow the pattern from learnings.md and match existing style in mail.tt and letsencrypt.tt.

## Testing
No automated test suite. Verified changes match the established idempotency patterns from the codebase (see mail.tt guards merged in PR #5, matrix.tt state-file pattern).