### PR TITLE
fix: guard core make targets and defer service restarts to postrun

### DIFF
--- a/templates/fail2ban.tt
+++ b/templates/fail2ban.tt
@@ -2,4 +2,4 @@ rm /etc/fail2ban/jail.d/[% domain %].conf; /bin/true
 rm /etc/fail2ban/filter.d/[% domain %].conf; /bin/true
 mv jail.cfg   /etc/fail2ban/jail.d/[% domain %].conf
 mv filter.cfg /etc/fail2ban/filter.d/[% domain %].conf
-systemctl reload fail2ban
+[% script_dir %]/queue_postrun_task systemctl reload fail2ban

--- a/templates/makefile.tt
+++ b/templates/makefile.tt
@@ -48,7 +48,7 @@ all:[% FOR target IN global_targets %] [% state_dir %]/[% target %][% END %][% F
 
 [% IF user %]
 [% state_dir %]/service_user:
-	useradd -s /usr/sbin/nologin -d [% install_dir %]/[% domain %] [% user %]
+	id [% user %] &>/dev/null || useradd -s /usr/sbin/nologin -d [% install_dir %]/[% domain %] [% user %]
 	mkdir -p [% install_dir %]/[% domain %]; /bin/true
 	chown [% user %]:[% admin_user %] [% install_dir %]/[% domain %]
 	touch $@
@@ -63,8 +63,8 @@ all:[% FOR target IN global_targets %] [% state_dir %]/[% target %][% END %][% F
 	mkdir -p '/etc/letsencrypt/live/[% domain %]'
 	openssl req -x509 -config openssl.conf -nodes -newkey rsa:4096 -subj '/CN=[% domain %]' -addext 'subjectAltName=DNS:www.[% domain %],DNS:mail.[% domain %][% full_aliases.join(',DNS:') %]' -keyout '/etc/letsencrypt/live/[% domain %]/privkey.pem' -out '/etc/letsencrypt/live/[% domain %]/fullchain.pem' -days 365
 	# Setup the link to LE certs
-	ln -s /etc/letsencrypt/live/[% domain %]/fullchain.pem /etc/ssl/certs/[% domain %].pem
-	ln -s /etc/letsencrypt/live/[% domain %]/privkey.pem /etc/ssl/private/[% domain %].pem
+	[ -L /etc/ssl/certs/[% domain %].pem ] || ln -s /etc/letsencrypt/live/[% domain %]/fullchain.pem /etc/ssl/certs/[% domain %].pem
+	[ -L /etc/ssl/private/[% domain %].pem ] || ln -s /etc/letsencrypt/live/[% domain %]/privkey.pem /etc/ssl/private/[% domain %].pem
 	touch $@
 
 # Be explicit about SSH security

--- a/templates/nginxproxy.tt
+++ b/templates/nginxproxy.tt
@@ -1,9 +1,8 @@
 # Setup global configuration
 mv nginx.global.conf /etc/nginx/conf.d/global.conf
-systemctl restart nginx
 # Setup the domain and its aliases
 mv nginx.domain.conf /etc/nginx/sites-enabled/[% domain %].conf
-systemctl restart nginx
+[% script_dir %]/queue_postrun_task systemctl restart nginx
 # Get ready for ACME
 mkdir -p [% install_dir %]/[% domain %]/www/.well_known; /bin/true
 chown [% user %]:www-data [% install_dir %]/[% domain %]/www/.well_known


### PR DESCRIPTION
## What
Guard unprotected `useradd` and `ln -s` operations in `makefile.tt` core targets; eliminate nginx double-restart and defer both nginx and fail2ban service reloads to `queue_postrun_task`.

## Why
Issue #1 calls for safe shared-environment deploys. PRs #5 and #6 cover individual recipes; this covers the **core makefile template** which runs for every domain:

- `service_user`: `useradd` fails with exit 9 if the service user already exists on an existing system — now guarded with `id user &>/dev/null ||`
- `ssl`: both `ln -s` symlinks for the self-signed cert fail if already present — guarded with `[ -L target ] ||`

Additionally, `nginxproxy.tt` was restarting nginx **twice** in sequence (once per config file installed) and both restarts fired inline mid-make. Collapsed to one deferred restart via `queue_postrun_task`, so nginx reloads only after all config is in place. `fail2ban.tt` had the same inline-reload problem.

## How
- `makefile.tt` `service_user` target: `id [% user %] &>/dev/null || useradd ...`
- `makefile.tt` `ssl` target: `[ -L /etc/ssl/certs/... ] || ln -s ...` (both symlinks)
- `nginxproxy.tt`: removed first inline `systemctl restart nginx`, replaced second with `[% script_dir %]/queue_postrun_task systemctl restart nginx`
- `fail2ban.tt`: `systemctl reload fail2ban` → `queue_postrun_task systemctl reload fail2ban`

All guards follow the same pattern established in PRs #5 and #6.

## Testing
No automated test suite. Changes verified by diff — patterns match the established guards in mail.tt, letsencrypt.tt, mariadb.tt, and tpsgi.tt from the merged and pending PRs.