### PR TITLE
fix: correct systemd path and defer service restarts in 3 recipes

### DIFF
--- a/templates/mounts.tt
+++ b/templates/mounts.tt
@@ -10,7 +10,7 @@
 csplit --suppress-matched --quiet --digits 1 --prefix mount -- fusemounts.txt "/--SEPARATOR--/" "{*}"
 [% END -%]
 [% FOREACH mount IN fuse %]
-mv mount[% loop.index %] /etc/systemd/service/[% mount.servicename %].service
+mv mount[% loop.index %] /etc/systemd/system/[% mount.servicename %].service
 sudo -u [% user %] systemctl --user enable [% mount.servicename %].service
 sudo -u [% user %] systemctl --user start  [% mount.servicename %]
 [% END -%]

--- a/templates/nostubresolver.tt
+++ b/templates/nostubresolver.tt
@@ -2,4 +2,4 @@ mkdir /etc/systemd/resolved.conf.d/; /bin/true
 cp 10-disable-stub-resolver.conf /etc/systemd/resolved.conf.d/
 chown -R systemd-resolve:systemd-resolve /etc/systemd/resolved.conf.d/
 chmod 0660 /etc/systemd/resolved.conf.d/10-disable-stub-resolver.conf
-systemctl restart systemd-resolved
+[% script_dir %]/queue_postrun_task systemctl restart systemd-resolved

--- a/templates/ufw.tt
+++ b/templates/ufw.tt
@@ -1,7 +1,7 @@
 mv ufw/* /etc/ufw/applications.d/
 chmod 0644 /etc/ufw/applications.d/*
 chown root:root /etc/ufw/applications.d/*
-systemctl restart ufw
+[% script_dir %]/queue_postrun_task systemctl restart ufw
 [% script_dir %]/setup-ufw-rules
 [% script_dir %]/setup-port-forwards [% FOR f IN port_forwards %] '[% f.from %]=[% f.to %]' [% END %]
 # In the event this is an outgoing-only sendmail box, enable outbound 25


### PR DESCRIPTION
## What
Three small fixes across mounts.tt, ufw.tt, and nostubresolver.tt.

## Why
- **mounts.tt**: `/etc/systemd/service/` doesn't exist on any standard systemd system — the directory is `/etc/systemd/system/`. Any fuse-mount service file installed via this recipe has been silently landing in a non-existent directory, making it impossible for systemctl to find the unit. This is a silent failure that would be extremely confusing to debug.
- **ufw.tt / nostubresolver.tt**: Both call `systemctl restart` inline in the make recipe, which fires mid-provisioning before all config is in place and breaks the execution order guarantee. Every other service restart in the codebase uses `queue_postrun_task` — these two were the outliers.

## How
- `mounts.tt`: `service` → `system`
- `ufw.tt`: `systemctl restart ufw` → `[% script_dir %]/queue_postrun_task systemctl restart ufw`
- `nostubresolver.tt`: `systemctl restart systemd-resolved` → `[% script_dir %]/queue_postrun_task systemctl restart systemd-resolved`

No other changes. Three lines.

## Testing
No test suite. Changes verified by diff. Patterns match every other recipe in the codebase.