### PR TITLE
fix: guard user .cache dir and defer postrun tasks in cron/auditd

### DIFF
--- a/templates/auditd.tt
+++ b/templates/auditd.tt
@@ -1,3 +1,3 @@
 mv global.rules /etc/audit/rules.d/global.rules
 mv domain.rules /etc/audit/rules.d/[% domain %].rules
-augenrules --load
+[% script_dir %]/queue_postrun_task augenrules --load

--- a/templates/cron.tt
+++ b/templates/cron.tt
@@ -17,9 +17,11 @@ crontab -u [% user %] user.crontab
 /root/bin/changes_in_packaged_files.sh; /bin/true
 # For cronie backups
 mkdir /root/.cache; /bin/true
+[% IF user %]
 mkdir [% install_dir %]/[% domain %]/.cache; /bin/true
 chown [% user %]:[% user %] [% install_dir %]/[% domain %]/.cache
+[% END -%]
 # Initialize rkhunter stuff
 mv rkhunter.conf /etc/rkhunter.conf
-rkhunter --propupd
+[% script_dir %]/queue_postrun_task rkhunter --propupd
 [% script_dir %]/queue_postrun_task systemctl restart cronie


### PR DESCRIPTION
## What
Two template fixes in `cron.tt` and `auditd.tt` that would cause silent failures or incorrect behavior on certain deploy configurations.

## Why
- `cron.tt` had `chown [% user %]:[% user %]` and `mkdir` for the user's `.cache` dir outside any `[% IF user %]` guard. If a domain has no service user configured, Template Toolkit expands `[% user %]` to empty string, generating `chown :` — an invalid command that fails the whole make target.
- `rkhunter --propupd` was running inline mid-make. It should run after all packages and files reach their final state, not partway through provisioning.
- `augenrules --load` in `auditd.tt` was running inline. Deferred to `queue_postrun_task` for consistency with every other recipe that triggers a service-affecting operation.

## How
- Wrapped the user `.cache` directory creation and ownership in `[% IF user %]` — matches the existing pattern already used for `crontab -u [% user %]` just above it.
- Both `rkhunter --propupd` and `augenrules --load` moved to `queue_postrun_task`, same pattern as `systemctl restart cronie` one line below.

## Testing
No automated test suite. Manually verified the rendered template output: without `user` set, the chown block is correctly absent; with `user` set, it renders as before.