### PR TITLE
fix: defer service restarts to postrun in mail, pdns, roundcube

### DIFF
--- a/templates/mail.tt
+++ b/templates/mail.tt
@@ -25,7 +25,7 @@ chown -R [% admin_user %]:[% admin_user %] /mail/keys
 mkdir /var/spool/postfix/opendkim
 chown opendkim:postfix /var/spool/postfix/opendkim
 chmod 0770 /var/spool/postfix/opendkim
-systemctl restart opendkim
+[% script_dir %]/queue_postrun_task systemctl restart opendkim
 # opendmarc
 mkdir -p /etc/opendmarc
 mv /etc/opendmarc.conf /etc/opendmarc.conf.orig
@@ -36,7 +36,7 @@ chown opendmarc:opendmarc /etc/opendmarc.conf
 mkdir /var/spool/postfix/opendmarc
 chown opendmarc:postfix /var/spool/postfix/opendmarc
 chmod 0770 /var/spool/postfix/opendmarc
-systemctl restart opendmarc
+[% script_dir %]/queue_postrun_task systemctl restart opendmarc
 # update DNS records IFF we have a dns server locally
 [% script_dir %]/queue_postrun_task [% script_dir %]/install_dkim_records [% domain %] /mail/[% domain %]/default.private
 # dovecot
@@ -47,7 +47,7 @@ mv dovecot.conf /etc/dovecot/conf.d/00-dovecot.conf
 mv dovecot.domain.conf /etc/dovecot/conf.d/10-[% domain %].conf
 sed -i "s/%REPLACEME%/$$(id -u dovecot)/gm" mailpasswd
 mv mailpasswd /mail/[% domain %]/passwd
-systemctl restart dovecot
+[% script_dir %]/queue_postrun_task systemctl restart dovecot
 # Stash a copy of the mailnames, and restore it if necessary
 # TODO make the old one take precedence via configuration
 mv [% install_dir %]/[% domain %]/mailnames/passwd [% install_dir %]/[% domain %]/mailnames/passwd.old; /bin/true
@@ -56,7 +56,7 @@ chown -R dovecot:dovecot /mail/[% domain %]/
 # amvavisd-new
 mv 50-user /etc/amavis/conf.d/
 chown root:root /etc/amavis/conf.d/50-user
-systemctl restart amavis
+[% script_dir %]/queue_postrun_task systemctl restart amavis
 # postfix
 mv aliases /etc/aliases
 chown root:root /etc/aliases
@@ -164,8 +164,6 @@ chmod 0600 /etc/postfix/master.cf
 # Fix any bad postmap perms
 chmod 0644 /etc/postfix/virtual/*.db
 chmod 0644 /etc/postfix/*.db
-# Restart
-systemctl restart postfix
 # Fix postfix's dumbass resolver copy grabbing a broken out of the box config (thank you systemd-resolved)
 [% script_dir %]/queue_postrun_task "cat /etc/resolv.conf > /var/spool/postfix/resolv.conf"
 [% script_dir %]/queue_postrun_task systemctl restart postfix

--- a/templates/pdns.tt
+++ b/templates/pdns.tt
@@ -40,15 +40,12 @@ mv /etc/powerdns/pdns.d/bind.conf /etc/powerdns/config-available/bind.conf; /bin
 mkdir -p /var/spool/powerdns/run/pdns/; /bin/true
 chown -R pdns:pdns /var/spool/powerdns/run
 mv 10-powerdns.conf /etc/rsyslog.d/10-powerdns.conf
-systemctl daemon-reload
-systemctl restart rsyslog
-systemctl enable pdns
-systemctl start pdns
-systemctl enable pdns-recursor
-systemctl start pdns-recursor
-# In case we are running this subsequently, start is a no-op then
-systemctl restart pdns
-systemctl restart pdns-recursor
+[% script_dir %]/queue_postrun_task systemctl daemon-reload
+[% script_dir %]/queue_postrun_task systemctl restart rsyslog
+[% script_dir %]/queue_postrun_task systemctl enable pdns
+[% script_dir %]/queue_postrun_task systemctl restart pdns
+[% script_dir %]/queue_postrun_task systemctl enable pdns-recursor
+[% script_dir %]/queue_postrun_task systemctl restart pdns-recursor
 # Setup lexicon shortcuts
 mkdir -p /opt/lexicon/[% domain %]; /bin/true
 mv lexicon-pdns.sh /opt/lexicon/[% domain %]/pdns

--- a/templates/roundcube.tt
+++ b/templates/roundcube.tt
@@ -4,7 +4,7 @@ wget -O [% install_dir %]/webmail.[% domain %]/roundcube.tar.gz https://github.c
 cd [% install_dir %]/webmail.[% domain %] && tar --strip-components=1 -zxvf roundcube.tar.gz
 install fpm.ini /etc/php/$(PHP_VER)/fpm/pool.d/roundcube-[% domain %].ini
 install config.inc.php [% install_dir %]/webmail.[% domain %]/config/config.inc.php
-systemctl restart php$(PHP_VER)-fpm
+[% script_dir %]/queue_postrun_task systemctl restart php$(PHP_VER)-fpm
 # Initialize the roundcube database, because autocreate is beyond them
 sqlite3 [% install_dir %]/webmail.[% domain %]_data/roundcube.db < [% install_dir %]/webmail.[% domain %]/SQL/sqlite.initial.sql
 chown -R www-data:www-data [% install_dir %]/webmail.[% domain %]_data


### PR DESCRIPTION
## What
Defer all inline `systemctl` restarts to `queue_postrun_task` in mail.tt, pdns.tt, and roundcube.tt.

## Why
Direct `systemctl restart` calls inside make recipe targets run immediately during provisioning, which causes issues on re-deploy: services are interrupted mid-make, and on some systems the restart fails if dependent sockets aren't yet ready. The pattern already established in letsencrypt.tt, tpsgi.tt, and matrix.tt uses `queue_postrun_task` so all service restarts happen after the full Makefile run completes.

For mail.tt specifically, the inline postfix restart (line 168) was redundant — an identical restart was already queued two lines later via `queue_postrun_task`. Removed the duplicate.

## How
- `mail.tt`: opendkim, opendmarc, dovecot, amavis restarts → queued; redundant inline postfix restart removed
- `pdns.tt`: daemon-reload, rsyslog, pdns, pdns-recursor → queued; collapse the enable+start+restart triplets into enable+restart (restart starts stopped services too)
- `roundcube.tt`: php-fpm restart → queued

Queue order preserved: milter services (opendkim/opendmarc) run before dovecot, dovecot before amavis, amavis before postfix — matching the existing dependency chain.

## Testing
No automated tests. Pattern matches established convention in letsencrypt.tt, tpsgi.tt, and all other fixed recipes from PRs #5-#9.