### PR TITLE
fix(matrix): flatten inner make targets to valid shell fragment

### DIFF
--- a/lib/Provisioner/Recipe/matrix.pm
+++ b/lib/Provisioner/Recipe/matrix.pm
@@ -171,11 +171,12 @@ sub template_files {
     my ($self) = @_;
 
     return (
-        'matrix.homeserver.yaml.tt' => 'homeserver.yaml',
-        'matrix.log.yaml.tt'        => 'log.yaml',
-        'matrix.nginx.tt'           => 'matrix.nginx.conf',
-        'matrix.admin.nginx.tt'     => 'matrix-admin.nginx.conf',
-        'matrix.synapse.service.tt' => 'matrix-synapse.service',
+        'matrix.homeserver.yaml.tt'      => 'homeserver.yaml',
+        'matrix.log.yaml.tt'             => 'log.yaml',
+        'matrix.nginx.tt'                => 'matrix.nginx.conf',
+        'matrix.admin.nginx.tt'          => 'matrix-admin.nginx.conf',
+        'matrix.synapse.service.tt'      => 'matrix-synapse.service',
+        'matrix.register_admin.sh.tt'    => 'matrix_register_admin.sh',
     );
 }
 

--- a/templates/files/matrix.register_admin.sh.tt
+++ b/templates/files/matrix.register_admin.sh.tt
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Wait for Matrix Synapse to be ready
+for i in {1..30}; do
+    if curl -s http://127.0.0.1:8008/_matrix/client/versions > /dev/null 2>&1; then
+        echo "Matrix Synapse is ready"
+        break
+    fi
+    echo "Waiting for Matrix Synapse to start... ($i/30)"
+    sleep 2
+done
+
+# Register admin user if not already registered
+su - matrix-synapse -s /bin/bash -c "register_new_matrix_user \
+    -c /etc/matrix-synapse/homeserver.yaml \
+    -u [% admin_user %] \
+    -p [% admin_password %] \
+    --admin 2>&1" | grep -q "User ID already taken" \
+    && echo "Admin user already exists" \
+    || echo "Admin user registered successfully"

--- a/templates/matrix.tt
+++ b/templates/matrix.tt
@@ -1,84 +1,35 @@
-[% state_dir %]/matrix: [% state_dir %]/scripts [% state_dir %]/packages
-	# Setup directories
-	mkdir -p [% install_dir %]/matrix.[% domain %]
-	mkdir -p [% install_dir %]/matrix.[% domain %]/media
-	mkdir -p [% install_dir %]/admin.matrix.[% domain %]
-	mkdir -p /etc/matrix-synapse
-	mkdir -p /var/log/matrix-synapse
-	# Set ownership using admin_user pattern
-	chown -R matrix-synapse:[% admin_user %] [% install_dir %]/matrix.[% domain %]
-	chmod -R 0750 [% install_dir %]/matrix.[% domain %]
-	chown -R matrix-synapse:matrix-synapse /var/log/matrix-synapse
-	# Deploy configuration files
-	cp homeserver.yaml /etc/matrix-synapse/
-	cp log.yaml /etc/matrix-synapse/
-	cp matrix-synapse.service /etc/systemd/system/
-	chown root:root /etc/matrix-synapse/homeserver.yaml
-	chown root:root /etc/matrix-synapse/log.yaml
-	chmod 0644 /etc/matrix-synapse/homeserver.yaml
-	chmod 0644 /etc/matrix-synapse/log.yaml
-	# Generate signing key if it doesn't exist
-	if [ ! -f [% install_dir %]/matrix.[% domain %]/homeserver.signing.key ]; then \
-		python3 -c "from synapse.crypto import key; print(key.generate_signing_key('ed25519').decode('ascii'))" > [% install_dir %]/matrix.[% domain %]/homeserver.signing.key; \
-		chown matrix-synapse:[% admin_user %] [% install_dir %]/matrix.[% domain %]/homeserver.signing.key; \
-		chmod 0600 [% install_dir %]/matrix.[% domain %]/homeserver.signing.key; \
-	fi
-	touch $@
-
-[% state_dir %]/matrix-admin: [% state_dir %]/matrix
-	# Download and setup Synapse Admin
-	[% script_dir %]/matrix.download-admin.sh [% install_dir %]/admin.matrix.[% domain %]
-	chown -R www-data:[% admin_user %] [% install_dir %]/admin.matrix.[% domain %]
-	chmod -R 0750 [% install_dir %]/admin.matrix.[% domain %]
-	touch $@
-
-[% state_dir %]/matrix-nginx: [% state_dir %]/matrix [% state_dir %]/matrix-admin
-	# Setup nginx sites
-	mkdir -p /etc/nginx/sites-enabled
-	cp matrix.nginx.conf /etc/nginx/sites-enabled/matrix.[% domain %].conf
-	cp matrix-admin.nginx.conf /etc/nginx/sites-enabled/admin.matrix.[% domain %].conf
-	chown root:root /etc/nginx/sites-enabled/matrix.[% domain %].conf
-	chown root:root /etc/nginx/sites-enabled/admin.matrix.[% domain %].conf
-	chmod 0644 /etc/nginx/sites-enabled/*.conf
-	touch $@
-
-[% state_dir %]/matrix-service: [% state_dir %]/matrix [% state_dir %]/matrix-nginx
-	# Enable service (actual start will be queued)
-	systemctl daemon-reload
-	systemctl enable matrix-synapse
-	# Queue service start for postrun
-	[% script_dir %]/queue_postrun_task systemctl start matrix-synapse
-	[% script_dir %]/queue_postrun_task systemctl reload nginx
-	touch $@
-
-[% state_dir %]/matrix-admin-user: [% state_dir %]/matrix-service
-	# Create script to register admin user after service is running
-	cat > [% script_dir %]/matrix_register_admin.sh <<'EOF'
-#!/bin/bash
-# Wait for Matrix Synapse to be ready
-for i in {1..30}; do
-    if curl -s http://127.0.0.1:8008/_matrix/client/versions > /dev/null 2>&1; then
-        echo "Matrix Synapse is ready"
-        break
-    fi
-    echo "Waiting for Matrix Synapse to start... ($i/30)"
-    sleep 2
-done
-
-# Register admin user if not exists
-if ! su - matrix-synapse -s /bin/bash -c "register_new_matrix_user -c /etc/matrix-synapse/homeserver.yaml -u [% admin_user %] -p [% admin_password %] --admin 2>&1" | grep -q "User ID already taken"; then
-    echo "Admin user registered successfully"
-else
-    echo "Admin user already exists"
+mkdir -p [% install_dir %]/matrix.[% domain %]
+mkdir -p [% install_dir %]/matrix.[% domain %]/media
+mkdir -p [% install_dir %]/admin.matrix.[% domain %]
+mkdir -p /etc/matrix-synapse
+mkdir -p /var/log/matrix-synapse
+chown -R matrix-synapse:[% admin_user %] [% install_dir %]/matrix.[% domain %]
+chmod -R 0750 [% install_dir %]/matrix.[% domain %]
+chown -R matrix-synapse:matrix-synapse /var/log/matrix-synapse
+cp homeserver.yaml /etc/matrix-synapse/homeserver.yaml
+cp log.yaml /etc/matrix-synapse/log.yaml
+cp matrix-synapse.service /etc/systemd/system/matrix-synapse.service
+chown root:root /etc/matrix-synapse/homeserver.yaml
+chown root:root /etc/matrix-synapse/log.yaml
+chmod 0644 /etc/matrix-synapse/homeserver.yaml
+chmod 0644 /etc/matrix-synapse/log.yaml
+if [ ! -f [% install_dir %]/matrix.[% domain %]/homeserver.signing.key ]; then \
+	python3 -c "from synapse.crypto import key; print(key.generate_signing_key('ed25519').decode('ascii'))" > [% install_dir %]/matrix.[% domain %]/homeserver.signing.key; \
+	chown matrix-synapse:[% admin_user %] [% install_dir %]/matrix.[% domain %]/homeserver.signing.key; \
+	chmod 0600 [% install_dir %]/matrix.[% domain %]/homeserver.signing.key; \
 fi
-EOF
-	chmod +x [% script_dir %]/matrix_register_admin.sh
-	# Queue admin user creation for postrun
-	[% script_dir %]/queue_postrun_task [% script_dir %]/matrix_register_admin.sh
-	touch $@
-
-# Since Matrix is listening on localhost only, no UFW rules needed
-# But we document this for clarity
-[% state_dir %]/matrix-firewall-note: [% state_dir %]/matrix-service
-	echo "Matrix Synapse listens on 127.0.0.1:8008 only - no firewall rules needed" > [% state_dir %]/matrix-firewall.note
-	touch $@
+[% script_dir %]/matrix.download-admin.sh [% install_dir %]/admin.matrix.[% domain %]
+chown -R www-data:[% admin_user %] [% install_dir %]/admin.matrix.[% domain %]
+chmod -R 0750 [% install_dir %]/admin.matrix.[% domain %]
+mkdir -p /etc/nginx/sites-enabled
+cp matrix.nginx.conf /etc/nginx/sites-enabled/matrix.[% domain %].conf
+cp matrix-admin.nginx.conf /etc/nginx/sites-enabled/admin.matrix.[% domain %].conf
+chmod 0644 /etc/nginx/sites-enabled/matrix.[% domain %].conf
+chmod 0644 /etc/nginx/sites-enabled/admin.matrix.[% domain %].conf
+cp matrix_register_admin.sh [% script_dir %]/matrix_register_admin.sh
+chmod +x [% script_dir %]/matrix_register_admin.sh
+[% script_dir %]/queue_postrun_task systemctl daemon-reload
+[% script_dir %]/queue_postrun_task systemctl enable matrix-synapse
+[% script_dir %]/queue_postrun_task systemctl start matrix-synapse
+[% script_dir %]/queue_postrun_task systemctl reload nginx
+[% script_dir %]/queue_postrun_task [% script_dir %]/matrix_register_admin.sh


### PR DESCRIPTION
## What
Rewrite `matrix.tt` from inner-make-target format to a flat shell fragment, and extract the admin registration script to a proper template file.

## Why
`matrix.tt` defined its own make sub-targets (`$(state_dir)/matrix:`, `$(state_dir)/matrix-admin:`, etc.) inside the recipe fragment. `makefile.tt` wraps every fragment with `tabinate`, which prefixes each line with a tab — converting those target-definition lines into tab-indented shell commands. Make then tries to execute them as shell, producing a command-not-found error. Every matrix deployment would fail immediately.

A second bug compounded this: the admin registration script was generated via a heredoc (`cat > file <<'EOF'`), which also fails in make because each recipe line runs in a separate subshell — the heredoc open and its content land in different shells and never connect.

## How
- `templates/matrix.tt` — remove all inner make targets; flatten to a sequential series of shell commands inside the single outer `$(state_dir)/matrix:` target that `makefile.tt` provides
- `templates/files/matrix.register_admin.sh.tt` — extract the admin registration script to a proper template file (rendered with admin credentials at provisioning time)
- `lib/Provisioner/Recipe/matrix.pm` — register the new template file in `template_files()` so it lands in the work dir as `matrix_register_admin.sh`
- All `systemctl` calls moved to `queue_postrun_task`, consistent with PRs #5–#10

The signing-key generation guard (`[ ! -f signing.key ]`) is preserved as-is.

## Testing
No automated test suite. Verified by diff review — the rendered output will now be a valid flat make recipe matching the pattern of every other recipe in the codebase (see `redis.tt`, `tpsgi.tt`, etc.).