### PR TITLE
fix(new_config): correct SFTP key path and datadir existence check

### DIFF
--- a/bin/new_config
+++ b/bin/new_config
@@ -378,7 +378,7 @@ sub handle_domain {
 
         # Make dirs in the DATADIR needed by ssh
         foreach my $d ( $builder->datadirs() ) {
-            make_path("$data_config->{from}/$fqdn/$d") unless -d $d;
+            make_path("$data_config->{from}/$fqdn/$d") unless -d "$data_config->{from}/$fqdn/$d";
         }
 
         # Schlep over stuff from existing deployments
@@ -387,7 +387,7 @@ sub handle_domain {
             foreach my $to_fetch ( sort keys(%tg) ) {
                 print "Writing remote file $to_fetch as $data_config->{from}/$fqdn/$tg{$to_fetch}\n";
                 # XXX deal with connection drops
-                ($ssh) = _get_sftp($static_ip, $admin_user) unless $ssh;
+                ($ssh) = _get_sftp($static_ip, $admin_user, $cfg_dir) unless $ssh;
                 my $num_copied = $ssh->rget(
                     $to_fetch,
                     "$data_config->{from}/$fqdn/$tg{$to_fetch}",
@@ -501,7 +501,7 @@ sub _get_sftp {
         host => $static_ip,
         user => $admin_user,
         more => [-o => "StrictHostKeyChecking=no", -o => 'UserKnownHostsFile=/dev/null'],
-        key_path => "$cfg_dir/key.rsa"
+        key_path => $key2use
     );
     $ssh->error or $target_is_up = 1;
     return ($ssh, $target_is_up)


### PR DESCRIPTION
## What
Three bug fixes in `bin/new_config`'s SFTP handling and datadir guard.

## Why
- `$key2use` was computed correctly (set to undef when `key.rsa` is absent) but the hardcoded string `"$cfg_dir/key.rsa"` was passed to `Net::SFTP::Foreign` instead — the file-existence guard was effectively dead code. When the key file doesn't exist, this would cause the SFTP connection to attempt (and fail) with a nonexistent key path rather than falling back to agent/password auth.
- The reconnect call on line 390 called `_get_sftp($static_ip, $admin_user)` without `$cfg_dir`, producing `"/key.rsa"` as the key path (undef interpolated to empty string).
- The `datadirs` guard checked `-d $d` (relative path from `datadirs()`) instead of `-d "$data_config->{from}/$fqdn/$d"` (the path actually being created), so it could skip creating a needed directory when an unrelated dir with the same short name happened to exist locally.

## How
- `key_path => "$cfg_dir/key.rsa"` → `key_path => $key2use`
- Reconnect: `_get_sftp($static_ip, $admin_user)` → `_get_sftp($static_ip, $admin_user, $cfg_dir)`
- Datadirs: `unless -d $d` → `unless -d "$data_config->{from}/$fqdn/$d"`

## Testing
No test suite. Changes are mechanical — each is a one-line substitution with obvious correct intent.