### PR TITLE
feat(ipmap2zones): implement zone file generator from ipmap.cfg

### DIFF
--- a/bin/ipmap2zones
+++ b/bin/ipmap2zones
@@ -1,2 +1,145 @@
-#!/bin/bash
-echo "TODO"
+#!/usr/bin/env perl
+
+package Trog::Provisioner::IPMap2Zones;
+
+use strict;
+use warnings FATAL => 'all';
+
+use FindBin;
+use FindBin::libs;
+
+use Config::Simple;
+use Text::Xslate;
+use Text::Xslate::Bridge::TT2;
+use Net::IP;
+use List::Util qw{uniq};
+use Getopt::Long qw{GetOptionsFromArray};
+use File::Slurper;
+
+=head1 ipmap2zones
+
+=head2 SYNOPSIS
+
+    ipmap2zones [--ipmap=file] [--output-dir=dir] [domain ...]
+
+=head2 DESCRIPTION
+
+Generate BIND-style zone files from ipmap.cfg, one file per domain.
+
+With no domain arguments, generates zone files for every domain in the [ips]
+section of ipmap.cfg.  Output is written to the current directory (or the
+directory specified with --output-dir) as C<domain.zone>.
+
+Zone files are rendered via C<templates/files/pdns.zone.tt> using the same
+variable set that C<new_config> would pass, so the output is identical to what
+the pdns recipe would install at provision time.
+
+=head2 OPTIONS
+
+=over 4
+
+=item --ipmap=FILE
+
+Path to ipmap.cfg.  Defaults to C<ipmap.cfg> in the current directory.
+
+=item --output-dir=DIR
+
+Directory to write zone files into.  Defaults to the current directory.  The
+directory must already exist.
+
+=back
+
+=cut
+
+my ( $cfile, $output_dir );
+
+sub main {
+    my @args = @_;
+
+    GetOptionsFromArray(
+        \@args,
+        'ipmap=s'      => \$cfile,
+        'output-dir=s' => \$output_dir,
+    );
+
+    $cfile      //= 'ipmap.cfg';
+    $output_dir //= '.';
+
+    die "No ipmap available at $cfile\n"     unless -f $cfile;
+    die "Output directory $output_dir does not exist\n" unless -d $output_dir;
+
+    my $c           = Config::Simple->new($cfile);
+    my $global_conf = $c->param( -block => 'global' );
+    my $ip_conf     = $c->param( -block => 'ips' );
+    my $alias_conf  = $c->param( -block => 'aliases' ) // {};
+    my $ns_conf     = $c->param( -block => 'nameservers' ) // {};
+
+    die "Must set admin_email in global section of $cfile\n"
+        unless $global_conf->{admin_email};
+
+    my @domains = @args ? @args : sort keys(%$ip_conf);
+    die "No domains defined in [ips] section of $cfile\n" unless @domains;
+
+    my $template_dir = "$FindBin::Bin/../templates";
+    my $tt = Text::Xslate->new(
+        {
+            path     => [$template_dir],
+            syntax   => 'TTerse',
+            module   => [qw{Text::Xslate::Bridge::TT2}],
+            function => { _formatters() },
+        }
+    );
+
+    foreach my $domain (@domains) {
+        die "No IP defined for '$domain' in [ips] section of $cfile\n"
+            unless $ip_conf->{$domain};
+
+        my $aliases = _coerce_arrayref( $alias_conf->{$domain} );
+        push( @$aliases, "www.$domain", "mail.$domain" );
+        $alias_conf->{$domain} = [ uniq @$aliases ];
+
+        my %vars = (
+            domain        => $domain,
+            ipmap         => $ip_conf,
+            aliases       => $alias_conf,
+            nameservers   => $ns_conf,
+            admin_email   => $global_conf->{admin_email},
+            serial        => time(),
+            extra_records => '',
+            modules       => [],
+        );
+
+        my $zone    = $tt->render( 'files/pdns.zone.tt', \%vars );
+        my $outfile = "$output_dir/$domain.zone";
+        File::Slurper::write_text( $outfile, $zone );
+        print "Wrote $outfile\n";
+    }
+
+    return 0;
+}
+
+sub _formatters {
+    return (
+        reverse_ip => Text::Xslate::html_builder(
+            sub {
+                my $ip = shift;
+                return Net::IP->new($ip)->reverse_ip();
+            }
+        ),
+        email_for_dns => Text::Xslate::html_builder(
+            sub {
+                my $email = shift;
+                $email =~ tr/@/./;
+                return $email;
+            }
+        ),
+    );
+}
+
+sub _coerce_arrayref {
+    my ($input) = @_;
+    return [] unless $input;
+    return ref $input eq 'ARRAY' ? $input : [$input];
+}
+
+main(@ARGV) unless caller;


### PR DESCRIPTION
## What
Replace the `bin/ipmap2zones` bash TODO stub with a functional Perl script that generates BIND-style zone files from `ipmap.cfg`.

## Why
The stub has existed since the repo was created. `new_config` generates zone files as a side-effect of full provisioning, but there's no way to regenerate them independently when IPs change in `ipmap.cfg` without re-running the entire provisioning pipeline. `ipmap2zones` fills that gap.

## How
Reuses the same `templates/files/pdns.zone.tt` template and the same variable set that `new_config` passes at provision time, so output is identical to what the pdns recipe installs.

- Parses `ipmap.cfg` with `Config::Simple` (same as `new_config`)
- For each domain in `[ips]`, renders `pdns.zone.tt` with the matching ipmap/aliases/nameservers data
- Writes `<domain>.zone` to `--output-dir` (defaults to `.`)
- Accepts optional domain arguments to generate only specific zone files

```sh
# Regenerate all zones
ipmap2zones

# Regenerate one zone after IP change
ipmap2zones example.tld

# Custom paths
ipmap2zones --ipmap /etc/provisioner/ipmap.cfg --output-dir /var/zones
```

## Testing
- `perl -c` passes (same dependency constraints as `new_config`)
- Logic follows `new_config`'s alias construction pattern exactly for consistency

🤖 Generated with [Claude Code](https://claude.ai/claude-code)