### PR TITLE
fix: defer service restarts, guard port-forward dups, fix adminconfig/synczones

### DIFF
--- a/lib/Provisioner/Recipe/adminconfig.pm
+++ b/lib/Provisioner/Recipe/adminconfig.pm
@@ -31,7 +31,7 @@ Optionally add in packages for the administrator to use on the provisioned host.
 sub deps {
     my ( $self, %opts ) = @_;
     if ( $self->{target_packager} eq 'deb' ) {
-        return @{ $opts{pkgs} } if ref $opts{pkgs} eq 'ARRAY';
+        return ref $opts{pkgs} eq 'ARRAY' ? @{ $opts{pkgs} } : ();
     }
     die "Unsupported packager";
 }

--- a/scripts/configure_pdns
+++ b/scripts/configure_pdns
@@ -26,5 +26,5 @@ $cfg->param("Service.WorkingDirectory", "/var/spool/powerdns");
 my $invocation = "/usr/sbin/pdns_server --guardian=no --daemon=no --logging-facility=1 --log-timestamp=yes --write-pid=no --chroot";
 $cfg->param("Service.ExecStart", $invocation);
 
-File::Copy::copy($service_file, "$service_file.bak");
+File::Copy::copy($service_file, "$service_file.bak") unless -f "$service_file.bak";
 $cfg->save();

--- a/scripts/setup-port-forwards
+++ b/scripts/setup-port-forwards
@@ -2,22 +2,23 @@
 
 [ $# -eq 0 ] && exit 0;
 
-sed -i '/^\*filter/i *nat' /etc/ufw/before.rules
-sed -i '/^\*filter/i :POSTROUTING ACCEPT [0:0]' /etc/ufw/before.rules
+RULES=/etc/ufw/before.rules
 
-for portmap in $@
-do
-    declare -a array
-    for port in $(echo $portmap | tr "=" "\n")
-    do
-        array+=("$port")
-    done
-    FROM=${array[0]}
-    TO=${array[1]}
+# Initialize NAT section if not already present
+if ! grep -q '^\*nat' "$RULES"; then
+    sed -i '/^\*filter/i *nat' "$RULES"
+    sed -i '/^\*filter/i :POSTROUTING ACCEPT [0:0]' "$RULES"
+fi
 
+# Add each PREROUTING rule if not already present
+for portmap in "$@"; do
+    FROM="${portmap%%=*}"
+    TO="${portmap##*=}"
     echo "Forwarding port $FROM to $TO"
-
-    sed -i "/^\*filter/i -A PREROUTING -p tcp --dport $FROM -j REDIRECT --to-port $TO" /etc/ufw/before.rules
+    grep -qF -- "--dport $FROM -j REDIRECT --to-port $TO" "$RULES" || \
+        sed -i "/^\*filter/i -A PREROUTING -p tcp --dport $FROM -j REDIRECT --to-port $TO" "$RULES"
 done
 
-sed -i '/^\*filter/i COMMIT\n' /etc/ufw/before.rules
+# Ensure NAT section ends with COMMIT (before *filter)
+awk '/^\*nat/{p=1} /^\*filter/{p=0} p && /^COMMIT/{found=1} END{exit !found}' "$RULES" || \
+    sed -i '/^\*filter/i COMMIT' "$RULES"

--- a/scripts/synczones
+++ b/scripts/synczones
@@ -121,14 +121,14 @@ sub zonediff {
         my $raw = $to_sync->plain;
         my $update_id = undef;
 
-        # Build plain form(s)
+        # Build plain form(s) — normalise remote content for comparison
         @$zones_actual = map {
             my $s = $_;
-            my $dquot = $_->{content} =~ s/"//g;
-            $s->{plain} = "$_->{name}. $_->{ttl} IN $_->{type} $_->{content}";
+            (my $dequoted = $_->{content}) =~ s/"//g;
+            $s->{plain} = "$_->{name}. $_->{ttl} IN $_->{type} $dequoted";
             $s->{pdot}  = "$s->{plain}.";
-            $s->{pquot} = qq|$_->{name}. $_->{ttl} IN $_->{type} "$_->{content}"|;
-            $s->{dquot} = qq|$_->{name}. $_->{ttl} IN $_->{type} $dquot|;
+            $s->{pquot} = qq|$_->{name}. $_->{ttl} IN $_->{type} "$dequoted"|;
+            $s->{dquot} = qq|$_->{name}. $_->{ttl} IN $_->{type} $dequoted|;
             $s
         } @$zones_actual;
 

--- a/templates/fail2ban.tt
+++ b/templates/fail2ban.tt
@@ -2,4 +2,4 @@ rm /etc/fail2ban/jail.d/[% domain %].conf; /bin/true
 rm /etc/fail2ban/filter.d/[% domain %].conf; /bin/true
 mv jail.cfg   /etc/fail2ban/jail.d/[% domain %].conf
 mv filter.cfg /etc/fail2ban/filter.d/[% domain %].conf
-systemctl reload fail2ban
+[% script_dir %]/queue_postrun_task systemctl reload fail2ban

--- a/templates/nginxproxy.tt
+++ b/templates/nginxproxy.tt
@@ -1,12 +1,11 @@
 # Setup global configuration
 mv nginx.global.conf /etc/nginx/conf.d/global.conf
-systemctl restart nginx
 # Setup the domain and its aliases
 mv nginx.domain.conf /etc/nginx/sites-enabled/[% domain %].conf
-systemctl restart nginx
 # Get ready for ACME
 mkdir -p [% install_dir %]/[% domain %]/www/.well_known; /bin/true
 chown [% user %]:www-data [% install_dir %]/[% domain %]/www/.well_known
 chmod 0755 [% install_dir %]/[% domain %]/www/.well_known
 # Deal with other demented deps that want apache2
 [% packager_remove_invocation %] apache2
+[% script_dir %]/queue_postrun_task systemctl restart nginx


### PR DESCRIPTION
## What
Final batch of fixes from the shared-environment safety audit (issue #1), covering nginxproxy, fail2ban, ufw port-forwarding, adminconfig, configure_pdns, and synczones.

## Why
Six issues across templates and scripts were not covered by PRs #5–#15:
- Inline `systemctl` calls in `fail2ban.tt` and `nginxproxy.tt` would restart services mid-provision instead of deferring
- `setup-port-forwards` inserted duplicate NAT rules in `/etc/ufw/before.rules` on every redeploy
- `adminconfig.pm` `deps()` fell through to `die "Unsupported packager"` when `pkgs` was omitted (valid config)
- `configure_pdns` overwrote the `.bak` of the original unit file on rerun, losing the pre-modification baseline
- `synczones` `zonediff()` stored the substitution count (an int) in `dquot` instead of the dequoted content string, making the TXT record normalization comparison always fail for that variant

## How
- `fail2ban.tt`, `nginxproxy.tt`: replace inline `systemctl` with `queue_postrun_task`, deduplicate the two nginx restarts to one
- `setup-port-forwards`: guard each `sed -i` with `grep -q`; use awk to check NAT COMMIT exists before adding it; simplify port parsing with `${portmap%%=*}` / `${portmap##*=}`
- `adminconfig.pm`: ternary instead of conditional return so deb+no-pkgs returns `()` rather than dying
- `configure_pdns`: add `unless -f "$service_file.bak"` so the original backup is preserved across reruns
- `synczones`: `(my $dequoted = $_->{content}) =~ s/"//g` — copy then strip, don't mutate the original hash value and capture a meaningless count

## Testing
Manual diff review and cross-check against all open PRs to confirm no overlap.