### PR TITLE
fix: make sendmail target idempotent, guard mariadb secure install

### DIFF
--- a/templates/makefile.tt
+++ b/templates/makefile.tt
@@ -43,8 +43,9 @@ all:[% FOR target IN global_targets %] [% state_dir %]/[% target %][% END %][% F
 	#XXX something mangles this later
 	test -f /etc/mail/sendmail.conf && chattr +ie /etc/mail/sendmail.conf; /bin/true
 	test -f /etc/mail/sendmail.conf && systemctl enable sendmail; /bin/true
-	test -f /etc/mail/sendmail.conf && systemctl restart sendmail; /bin/true
+	test -f /etc/mail/sendmail.conf && [% script_dir %]/queue_postrun_task systemctl restart sendmail; /bin/true
 	newaliases
+	touch $@
 
 [% IF user %]
 [% state_dir %]/service_user:

--- a/templates/mariadb.tt
+++ b/templates/mariadb.tt
@@ -5,8 +5,6 @@ ln -s /opt/mysql /opt/mariadb
 # Install global schema for the recipe
 useradd -s /usr/sbin/nologin -d /opt/mariadb mysql 
 [% script_dir %]/install_mariadb.sh [% user %] [% version %] [% install_dir %]/[% domain %]/[% dumpfile %]
-# Secure the mysql install
-mv secure_installation.sql /opt/mysql
-mysql --defaults-file=/opt/mariadb/my.cnf -sfu root < /opt/mysql/secure_installation.sql
-# Needs to be done, this has a hardcoded pw in it
-rm /opt/mysql/secure_installation.sql
+# Secure the mysql install (run once — root_pw is baked into the sql file)
+[ -f /opt/mysql/.secured ] || (mv secure_installation.sql /opt/mysql && mysql --defaults-file=/opt/mariadb/my.cnf -sfu root < /opt/mysql/secure_installation.sql && touch /opt/mysql/.secured)
+rm -f secure_installation.sql /opt/mysql/secure_installation.sql


### PR DESCRIPTION
## What
Two independent idempotency gaps not covered by any of PRs #5–#16.

## Why
**sendmail target** (`makefile.tt`): had no `touch $@`, so Make never considered the target "done" — `systemctl restart sendmail` fired on **every** `make` invocation (every redeploy, test run, or manual make call). On a shared system this causes needless service churn. Also, the restart was inline rather than deferred.

**mariadb secure installation** (`mariadb.tt`): `secure_installation.sql` (which contains the root password in plaintext) was rendered, copied to `/opt/mysql`, executed, and deleted on **every** deploy. While the SQL itself is idempotent, writing credentials to disk and re-running the secure-install block on every redeploy is unnecessary and slightly risky.

## How
- `makefile.tt`: defer `systemctl restart sendmail` via `queue_postrun_task` (consistent with every other service restart in the codebase); add `touch $@` so the target is stamped done after first successful run.
- `mariadb.tt`: guard the secure-install block with `[ -f /opt/mysql/.secured ] ||`; touch the marker on success; use `rm -f` to clean up from both the staging dir and `/opt/mysql` regardless of which path was taken.

## Testing
No automated test suite. Verified diff against all open PRs — no overlap on these specific changes. Patterns follow established guards from the codebase (queue_postrun_task, state file guards).

Note: this PR modifies `makefile.tt` (also touched by PR #7) and `mariadb.tt` (also touched by PR #6) — different lines, minor conflict to resolve at merge time.