### PR TITLE
fix: guard symlinks and grep-q in build_latest_perl.sh and build_imagick.sh

### DIFF
--- a/scripts/build_imagick.sh
+++ b/scripts/build_imagick.sh
@@ -4,13 +4,13 @@ VERSION=$1
 
 export NICE_PERL_NAME=$(find /opt/perl5 -maxdepth 1 -mindepth 1 -type d | tail -n1 | xargs basename)
 if [ ! $(/opt/perl5/$NICE_PERL_NAME/bin/perl -MImage::Magick -e 'print "OK" if Image::Magick::VERSION') ]; then
-	mkdir /tmp/imagick; /bin/true
+	mkdir -p /tmp/imagick
 	curl -L https://download.imagemagick.org/archive/releases/ImageMagick-$VERSION.tar.xz -o /tmp/imagick/imagemagick.tar.xz
 	cd /tmp/imagick && tar --one-top-level=src --strip-components=1 -xf /tmp/imagick/imagemagick.tar.xz
 	cd /tmp/imagick/src && ./configure --with-perl=/opt/perl5/$NICE_PERL_NAME/bin/perl --with-gslib
 	cd /tmp/imagick/src && make -j8
 	cd /tmp/imagick/src && make install
-	[ $(grep "/usr/local/lib" /etc/ld.so.conf) ] || echo "/usr/local/lib/" >> /etc/ld.so.conf
+	grep -q "/usr/local/lib" /etc/ld.so.conf || echo "/usr/local/lib/" >> /etc/ld.so.conf
 	ldconfig
 	/opt/perl5/$NICE_PERL_NAME/bin/perl -MImage::Magick -e 'print $Image::Magick::VERSION'
 fi

--- a/scripts/build_latest_perl.sh
+++ b/scripts/build_latest_perl.sh
@@ -40,7 +40,8 @@ fi
 
 # Build some symlinks to the perl for use by other? setup scripts
 mkdir -p $CLIENT_HOMEDIR/bin
-ln -s /opt/perl5/$NICE_PERL_NAME/bin/perl  $CLIENT_HOMEDIR/bin/perl
-ln -s /opt/perl5/$NICE_PERL_NAME/bin/cpanm $CLIENT_HOMEDIR/bin/cpanm
-ln -s /opt/perl5/$NICE_PERL_NAME/bin/perl  /root/bin/perl
-ln -s /opt/perl5/$NICE_PERL_NAME/bin/cpanm /root/bin/cpanm
+mkdir -p /root/bin
+[ -L $CLIENT_HOMEDIR/bin/perl  ] || ln -s /opt/perl5/$NICE_PERL_NAME/bin/perl  $CLIENT_HOMEDIR/bin/perl
+[ -L $CLIENT_HOMEDIR/bin/cpanm ] || ln -s /opt/perl5/$NICE_PERL_NAME/bin/cpanm $CLIENT_HOMEDIR/bin/cpanm
+[ -L /root/bin/perl  ] || ln -s /opt/perl5/$NICE_PERL_NAME/bin/perl  /root/bin/perl
+[ -L /root/bin/cpanm ] || ln -s /opt/perl5/$NICE_PERL_NAME/bin/cpanm /root/bin/cpanm


### PR DESCRIPTION
## What
Two idempotency/correctness fixes in the perl and imagick build scripts.

## Why
**`build_latest_perl.sh`**: Four `ln -s` calls (lines 43–46) were unguarded. On any re-run after initial provision they fail with "File exists", aborting the script. Also: `/root/bin` was never created before the symlinks into it, so even the first run would fail if `/root/bin` didn't already exist.

**`build_imagick.sh`**: `[ $(grep "/usr/local/lib" /etc/ld.so.conf) ]` uses the same word-splitting-on-grep-output pattern flagged in PR #15. If the line is found, `$(grep ...)` returns a path string that may contain spaces or appear multiple times — this is fragile and can silently misbehave depending on shell word-splitting.

## How
- `build_latest_perl.sh`: `[ -L target ] || ln -s ...` guard on all four symlinks; `mkdir -p /root/bin` before the symlinks into it. Matches the pattern used everywhere else in the codebase.
- `build_imagick.sh`: `grep -q "/usr/local/lib" /etc/ld.so.conf || echo ...` — clean idiom, no word-splitting. Also changed `mkdir /tmp/imagick; /bin/true` to `mkdir -p /tmp/imagick`.

## Testing
`bash -n` passes on both scripts. Changes are mechanical guards matching established patterns.