### PR TITLE
fix: idempotent unit files in mount_virtiofs, safe glob in retention.sh

### DIFF
--- a/scripts/mount_virtiofs
+++ b/scripts/mount_virtiofs
@@ -5,33 +5,40 @@ LINK_NAME=$2
 TYPE=$3
 
 ACTUAL_TARGET=$(grep "^$TARGET" /root/devices.map | awk -F "=" '{print $2}')
-LINK_NAME_REPLACED=$(echo "$LINK_NAME" | sed -e "s|^/||" | sed -e "s|/|-|")
-mkdir -p $LINK_NAME
+if [ -z "$ACTUAL_TARGET" ]; then
+    echo "Error: no device found for $TARGET in /root/devices.map" >&2
+    exit 1
+fi
 
-# Actually mount it
-MNTFILE="/usr/lib/systemd/system/$LINK_NAME_REPLACED.mount"
+LINK_NAME_REPLACED=$(echo "$LINK_NAME" | sed -e "s|^/||" -e "s|/|-|g")
+mkdir -p "$LINK_NAME"
 
-echo "[Unit]" >> $MNTFILE
-echo "Description=Shared dir from HV" >> $MNTFILE
-echo "After=multi-user.target" >> $MNTFILE
-echo "[Mount]" >> $MNTFILE
-echo "What=$ACTUAL_TARGET" >> $MNTFILE
-echo "Where=$LINK_NAME" >> $MNTFILE
-echo "Type=virtiofs" >> $MNTFILE
-echo "[Install]" >> $MNTFILE
-echo "WantedBy=multi-user.target" >> $MNTFILE
+MNTFILE="/usr/lib/systemd/system/${LINK_NAME_REPLACED}.mount"
+AUTOMNTFILE="/usr/lib/systemd/system/${LINK_NAME_REPLACED}.automount"
 
-AUTOMNTFILE="/usr/lib/systemd/system/$LINK_NAME_REPLACED.automount"
-echo "[Unit]" >> $AUTOMNTFILE
-echo "Description=Automount $LINK_NAME" >> $AUTOMNTFILE
-echo "ConditionPathExists=$LINK_NAME" >> $AUTOMNTFILE
-echo "[Automount]" >> $AUTOMNTFILE
-echo "Where=$LINK_NAME" >> $AUTOMNTFILE
-echo "TimeoutIdleSec=10" >> $AUTOMNTFILE
-echo "[Install]" >> $AUTOMNTFILE
-echo "WantedBy=multi-user.target" >> $AUTOMNTFILE
+cat > "$MNTFILE" << EOF
+[Unit]
+Description=Shared dir from HV
+After=multi-user.target
+[Mount]
+What=$ACTUAL_TARGET
+Where=$LINK_NAME
+Type=virtiofs
+[Install]
+WantedBy=multi-user.target
+EOF
+
+cat > "$AUTOMNTFILE" << EOF
+[Unit]
+Description=Automount $LINK_NAME
+ConditionPathExists=$LINK_NAME
+[Automount]
+Where=$LINK_NAME
+TimeoutIdleSec=10
+[Install]
+WantedBy=multi-user.target
+EOF
 
 systemctl daemon-reload
-systemctl enable $LINK_NAME_REPLACED.mount
-systemctl start $LINK_NAME_REPLACED.mount
-#mount -t virtiofs $ACTUAL_TARGET $LINK_NAME
+systemctl enable "${LINK_NAME_REPLACED}.mount"
+systemctl start "${LINK_NAME_REPLACED}.mount"

--- a/scripts/retention.sh
+++ b/scripts/retention.sh
@@ -7,17 +7,19 @@ CUTOFF=$(date -d"-1 months" +%s)
 
 declare DIRS=("$BASE_DIR/$BACKUP_HOST");
 
+shopt -s nullglob
 for dir in "${DIRS[@]}"
 do
     logger --stderr "Pruning $dir..."
-    for subdir in $dir/*
+    for subdir in "$dir"/*
     do
-        CUR_DATE=$(basename $subdir)
-        CUR_TIME=$(date -d"$CUR_DATE" +%s)
-        if [ $CUR_TIME -lt $CUTOFF ]
+        CUR_DATE=$(basename "$subdir")
+        CUR_TIME=$(date -d"$CUR_DATE" +%s 2>/dev/null)
+        [ -z "$CUR_TIME" ] && continue
+        if [ "$CUR_TIME" -lt "$CUTOFF" ]
         then
             logger --stderr "Deleting $subdir"
-            rm -rf $subdir
+            rm -rf "$subdir"
         fi
     done
 done


### PR DESCRIPTION
## What
Two script fixes: idempotent systemd unit file creation in `mount_virtiofs` and safe directory iteration in `retention.sh`.

## Why
**`mount_virtiofs`**: Used `echo >> $MNTFILE` for every line of the `.mount` and `.automount` unit files. On any re-provisioning run the files accumulate duplicate `[Unit]`, `[Mount]`, `[Automount]` sections — systemd rejects malformed units. Also: if `ACTUAL_TARGET` is empty (device not found in `devices.map`), the script silently wrote a broken `What=` entry; and the single `sed -e "s|/|-|"` only replaced the first `/`, leaving mount unit names malformed for paths with multiple components.

**`retention.sh`**: Two bugs in the inner loop — unquoted `$dir/*` expands to the literal glob string when the directory is empty, and an unparseable `basename` (a non-date-named directory) leaves `CUR_TIME` empty, making `[ $CUR_TIME -lt $CUTOFF ]` fail with "integer expression expected".

## How
- `mount_virtiofs`: Replace `echo >>` chains with `cat >` heredocs (always write clean file); validate `ACTUAL_TARGET` is non-empty before touching anything; fix sed to `s|/|-|g` (global replace); quote all variables.
- `retention.sh`: Add `shopt -s nullglob` so an empty directory produces zero iterations; quote `$dir` and `$subdir` throughout; suppress `date` stderr and skip entries whose basename doesn't parse as a date.

## Testing
`bash -n` passes on both scripts. Logic changes are mechanical guards following patterns already used elsewhere in the repo.