### PR TITLE
fix: guard fstab/mount, ln-s, ufw reset, dead mail.pm code

### DIFF
--- a/lib/Provisioner/Recipe/mail.pm
+++ b/lib/Provisioner/Recipe/mail.pm
@@ -27,8 +27,10 @@ use parent qw{Provisioner::Recipe};
                         - "INBOX.foo"
                         - "INBOX.bar"
             mail_aliases:
-                - Me: you
-                - You: me
+                - from: Me
+                  to: you
+                - from: You
+                  to: me
 
 =head2 DESCRIPTION
 
@@ -68,10 +70,6 @@ sub dep_conflicts {
 
 sub validate {
     my ( $self, %vars ) = @_;
-
-    if ( $vars{forwarders} ) {
-        die "aliases must be ARRAY" unless ref $vars{aliases} eq 'ARRAY';
-    }
 
     if ( $vars{names} ) {
         die "names must be HASH" unless ref $vars{names} eq 'HASH';

--- a/scripts/add_to_fstab
+++ b/scripts/add_to_fstab
@@ -17,6 +17,6 @@ cp /etc/fstab /tmp/fstab.new
 echo "$ACTUAL_TARGET $LINK_NAME $TYPE $OPTIONS 0 0" >> /tmp/fstab.new
 sort < /tmp/fstab.new | uniq | grep -o '^[^#]*' > /tmp/fstab.newer
 chown root:root /tmp/fstab.newer
-mv /etc/fstab /etc/fstab.bak
+[ -f /etc/fstab.bak ] || mv /etc/fstab /etc/fstab.bak
 mv /tmp/fstab.newer /etc/fstab
-mount $LINK_NAME
+mountpoint -q "$LINK_NAME" || mount "$LINK_NAME"

--- a/scripts/install_mariadb.sh
+++ b/scripts/install_mariadb.sh
@@ -34,7 +34,7 @@ wait_for_no_mysql() {
 
 
 if [ ! -f /opt/mysql/bin/mariadbd ]; then
-    ln -s /usr/lib/x86_64-linux-gnu/libaio.so.1t64 /usr/lib/x86_64-linux-gnu/libaio.so.1
+    [ -e /usr/lib/x86_64-linux-gnu/libaio.so.1 ] || ln -s /usr/lib/x86_64-linux-gnu/libaio.so.1t64 /usr/lib/x86_64-linux-gnu/libaio.so.1
     mkdir -p /opt/mysql
     curl -so /tmp/mysql.tar.gz -- https://archive.mariadb.org/mariadb-$VERSION/bintar-linux-systemd-x86_64/mariadb-$VERSION-linux-systemd-x86_64.tar.gz
     stat /tmp/mysql.tar.gz
@@ -51,7 +51,7 @@ if [ ! -f /opt/mysql/bin/mariadbd ]; then
 
     # Initialize the DB
     /opt/mysql/scripts/mariadb-install-db --defaults-file=/opt/mysql/my.cnf
-    ln -s /opt/mysql/mariadb.service /usr/lib/systemd/system/mariadb.service
+    [ -L /usr/lib/systemd/system/mariadb.service ] || ln -s /opt/mysql/mariadb.service /usr/lib/systemd/system/mariadb.service
     systemctl enable mariadb
     systemctl start  mariadb
 

--- a/scripts/setup-ufw-rules
+++ b/scripts/setup-ufw-rules
@@ -13,9 +13,15 @@ use warnings;
 
 Configure UFW firewall rules based on available applications.
 
+On first run (UFW inactive), resets to a known-clean state before applying rules.
+On subsequent runs (UFW already active), skips the destructive reset and only
+adds missing rules — safe for shared environments and redeployment.
+
 =cut
 
 my $DRY_RUN = $ARGV[0] ? 1 : 0;
+
+my $ufw_active = (qx{ufw status} =~ /Status: active/);
 
 # Enable every available service.
 my $list = qx{ufw app list};
@@ -23,13 +29,18 @@ my @apps = split(/\n/, $list);
 shift @apps;
 @apps = map { s/^\s+//; $_ } @apps;
 
-# Sane defaults
-my @rules = (
-    [qw{reset}],
-    [qw{enable}],
-    [qw{default deny outgoing}],
-    [qw{default deny incoming}],
-);
+# On first run only: reset to clean slate, then enable with sane defaults.
+# Skip reset on subsequent runs to avoid disrupting established connections
+# and dropping any manually-added rules on shared systems.
+my @rules;
+unless ($ufw_active) {
+    push @rules, (
+        [qw{--force reset}],
+        [qw{enable}],
+        [qw{default deny outgoing}],
+        [qw{default deny incoming}],
+    );
+}
 
 # Allow, but rate limit
 foreach my $app (@apps) {

--- a/scripts/setup_chroot_mount
+++ b/scripts/setup_chroot_mount
@@ -9,6 +9,6 @@ cp /etc/fstab /tmp/fstab.new
 echo "$TARGET $LINK_NAME none defaults,bind 0 0" >> /tmp/fstab.new
 sort < /tmp/fstab.new | uniq | grep -o '^[^#]*' > /tmp/fstab.newer
 chown root:root /tmp/fstab.newer
-mv /etc/fstab /etc/fstab.bak
+[ -f /etc/fstab.bak ] || mv /etc/fstab /etc/fstab.bak
 mv /tmp/fstab.newer /etc/fstab
-mount $TARGET
+mountpoint -q "$LINK_NAME" || mount "$TARGET"


### PR DESCRIPTION
## What
Guard destructive operations in four scripts and remove dead validation code in mail.pm — all missed by previous idempotency PRs.

## Why
These scripts weren't covered by any of the open idempotency PRs (#5–#19). Together they would fail or corrupt state on redeploy in a shared environment:
- `add_to_fstab`/`setup_chroot_mount`: `.bak` overwrite destroys original; `mount` without guard fails with EBUSY on rerun
- `install_mariadb.sh`: two unguarded `ln -s` calls inside the install block would fail if a prior system install left those symlinks
- `setup-ufw-rules`: `ufw reset` destroys ALL firewall rules on every run, briefly opening the host and wiping manually-added rules
- `mail.pm`: dead `forwarders` block validated a non-existent `aliases` field; SYNOPSIS showed wrong `mail_aliases` format

## How
- `[ -f /etc/fstab.bak ] || mv ...` and `mountpoint -q "$LINK_NAME" || mount` in fstab scripts
- `[ -e ... ] || ln -s` and `[ -L ... ] || ln -s` in install_mariadb.sh
- `setup-ufw-rules`: check `ufw status` on entry; skip `--force reset`/`enable`/defaults when UFW is already active — only apply app rules, which are idempotent
- `mail.pm`: drop the unreachable `forwarders` block; fix SYNOPSIS to match `from`/`to` keys the template and validator expect

## Testing
No automated test suite. Changes follow patterns already established in PRs #6, #7, #18, #19 (same guard idioms). The UFW change preserves first-run behavior exactly; only skips the destructive reset on subsequent runs.