### PR TITLE
fix: guard remaining scripts and templates for safe re-deploy

### DIFF
--- a/scripts/add_to_fstab
+++ b/scripts/add_to_fstab
@@ -17,6 +17,6 @@ cp /etc/fstab /tmp/fstab.new
 echo "$ACTUAL_TARGET $LINK_NAME $TYPE $OPTIONS 0 0" >> /tmp/fstab.new
 sort < /tmp/fstab.new | uniq | grep -o '^[^#]*' > /tmp/fstab.newer
 chown root:root /tmp/fstab.newer
-mv /etc/fstab /etc/fstab.bak
+[ -f /etc/fstab.bak ] || mv /etc/fstab /etc/fstab.bak
 mv /tmp/fstab.newer /etc/fstab
-mount $LINK_NAME
+mountpoint -q "$LINK_NAME" || mount $LINK_NAME

--- a/scripts/configure_pdns
+++ b/scripts/configure_pdns
@@ -26,5 +26,5 @@ $cfg->param("Service.WorkingDirectory", "/var/spool/powerdns");
 my $invocation = "/usr/sbin/pdns_server --guardian=no --daemon=no --logging-facility=1 --log-timestamp=yes --write-pid=no --chroot";
 $cfg->param("Service.ExecStart", $invocation);
 
-File::Copy::copy($service_file, "$service_file.bak");
+File::Copy::copy($service_file, "$service_file.bak") unless -f "$service_file.bak";
 $cfg->save();

--- a/scripts/setup-ufw-rules
+++ b/scripts/setup-ufw-rules
@@ -17,21 +17,26 @@ Configure UFW firewall rules based on available applications.
 
 my $DRY_RUN = $ARGV[0] ? 1 : 0;
 
+my $active = (qx{ufw status} =~ /Status: active/);
+
 # Enable every available service.
 my $list = qx{ufw app list};
 my @apps = split(/\n/, $list);
 shift @apps;
 @apps = map { s/^\s+//; $_ } @apps;
 
-# Sane defaults
-my @rules = (
-    [qw{reset}],
-    [qw{enable}],
-    [qw{default deny outgoing}],
-    [qw{default deny incoming}],
-);
+# Only reset and re-enable when UFW is not already active — reset briefly drops
+# the firewall which is disruptive on a running system.
+my @rules;
+unless ($active) {
+    push @rules,
+        [qw{reset}],
+        [qw{enable}],
+        [qw{default deny outgoing}],
+        [qw{default deny incoming}];
+}
 
-# Allow, but rate limit
+# Allow, but rate limit — these are idempotent and safe to reapply.
 foreach my $app (@apps) {
     push(@rules,
         ["allow", "out", $app],

--- a/scripts/setup_chroot_mount
+++ b/scripts/setup_chroot_mount
@@ -9,6 +9,6 @@ cp /etc/fstab /tmp/fstab.new
 echo "$TARGET $LINK_NAME none defaults,bind 0 0" >> /tmp/fstab.new
 sort < /tmp/fstab.new | uniq | grep -o '^[^#]*' > /tmp/fstab.newer
 chown root:root /tmp/fstab.newer
-mv /etc/fstab /etc/fstab.bak
+[ -f /etc/fstab.bak ] || mv /etc/fstab /etc/fstab.bak
 mv /tmp/fstab.newer /etc/fstab
-mount $TARGET
+mountpoint -q "$LINK_NAME" || mount $TARGET

--- a/templates/backup.tt
+++ b/templates/backup.tt
@@ -1,3 +1,4 @@
-rm [% install_dir %]/[% domain %]/[% key_file %]
+rm -f [% install_dir %]/[% domain %]/[% key_file %]
 mv rsyncd.conf /root/rsyncd.conf
+grep -qF '[% pubkey %]' /root/.ssh/authorized_keys 2>/dev/null || \
 echo "command=\"rsync --daemon --server --config=/root/rsyncd.conf .\",no-agent-forwarding,no-port-forwarding,no-pty,no-user-rc,no-X11-forwarding [% pubkey %]" >> /root/.ssh/authorized_keys

--- a/templates/fail2ban.tt
+++ b/templates/fail2ban.tt
@@ -2,4 +2,4 @@ rm /etc/fail2ban/jail.d/[% domain %].conf; /bin/true
 rm /etc/fail2ban/filter.d/[% domain %].conf; /bin/true
 mv jail.cfg   /etc/fail2ban/jail.d/[% domain %].conf
 mv filter.cfg /etc/fail2ban/filter.d/[% domain %].conf
-systemctl reload fail2ban
+[% script_dir %]/queue_postrun_task systemctl reload fail2ban

--- a/templates/nginxproxy.tt
+++ b/templates/nginxproxy.tt
@@ -1,9 +1,8 @@
 # Setup global configuration
 mv nginx.global.conf /etc/nginx/conf.d/global.conf
-systemctl restart nginx
 # Setup the domain and its aliases
 mv nginx.domain.conf /etc/nginx/sites-enabled/[% domain %].conf
-systemctl restart nginx
+[% script_dir %]/queue_postrun_task systemctl restart nginx
 # Get ready for ACME
 mkdir -p [% install_dir %]/[% domain %]/www/.well_known; /bin/true
 chown [% user %]:www-data [% install_dir %]/[% domain %]/www/.well_known

--- a/templates/tpsgi.tt
+++ b/templates/tpsgi.tt
@@ -1,6 +1,7 @@
 mkdir -p '[% install_dir %]/[% domain %]/www';  /bin/true
 mkdir -p '[% install_dir %]/[% domain %]/run';  /bin/true
-cd '[% install_dir %]/[% domain %]' && git clone --no-checkout https://github.com/Troglodyne-Internet-Widgets/tPSGI.git repo && mv repo/.git .git && rmdir repo
+[ -d '[% install_dir %]/[% domain %]/.git' ] || \
+(cd '[% install_dir %]/[% domain %]' && git clone --no-checkout https://github.com/Troglodyne-Internet-Widgets/tPSGI.git repo && mv repo/.git .git && rmdir repo)
 HOME='[% install_dir %]/[% domain %]' git config --global --add safe.directory '[% install_dir %]/[% domain %]'
 cd '[% install_dir %]/[% domain %]' && HOME='[% install_dir %]/[% domain %]' git reset --hard HEAD
 mv tpsgi.ini '[% install_dir %]/[% domain %]/.tpsgi.ini'
@@ -8,6 +9,7 @@ chown -R [% user %]:[% admin_user %] '[% install_dir %]/[% domain %]'
 chown -R [% user %]:www-data '[% install_dir %]/[% domain %]/www'
 chown -R [% user %]:www-data '[% install_dir %]/[% domain %]/run'
 chmod -R 0755 '[% install_dir %]/[% domain %]'
+[ -L /usr/lib/systemd/system/[% domain %].service ] || \
 ln -s [% install_dir %]/[% domain %]/service/tpsgi.service /usr/lib/systemd/system/[% domain %].service
 # We can't guarantee that perl has installed yet.
 # the PATH shenanigans here ensure we get the *right* perl

--- a/templates/ufw.tt
+++ b/templates/ufw.tt
@@ -1,8 +1,8 @@
 mv ufw/* /etc/ufw/applications.d/
 chmod 0644 /etc/ufw/applications.d/*
 chown root:root /etc/ufw/applications.d/*
-systemctl restart ufw
-[% script_dir %]/setup-ufw-rules
-[% script_dir %]/setup-port-forwards [% FOR f IN port_forwards %] '[% f.from %]=[% f.to %]' [% END %]
+[% script_dir %]/queue_postrun_task systemctl restart ufw
+[% script_dir %]/queue_postrun_task [% script_dir %]/setup-ufw-rules
+[% script_dir %]/queue_postrun_task [% script_dir %]/setup-port-forwards[% FOR f IN port_forwards %] '[% f.from %]=[% f.to %]'[% END %]
 # In the event this is an outgoing-only sendmail box, enable outbound 25
-test -f /etc/mail/sendmail.conf && ufw allow out 25; /bin/true
+[% script_dir %]/queue_postrun_task "test -f /etc/mail/sendmail.conf && ufw allow out 25; /bin/true"


### PR DESCRIPTION
## What

Guard remaining unprotected scripts and templates to make re-deployment on shared/existing systems safe.

## Why

Issue #1 tracks making all provisioners safe for shared-environment deploys. This PR fixes the last batch of unguarded operations not covered by PRs #5–#19: five scripts and four templates that would fail or cause disruption when run against a system that already has services configured.

## How

**Scripts:**
- `configure_pdns`: one-time backup guard — don't overwrite `.bak` if it already exists (same pattern as other scripts fixed in #16)
- `setup-ufw-rules`: check `ufw status` before resetting — skip reset+enable when UFW is already active; only reapply app rules, which are idempotent. Avoids briefly dropping the firewall on a live system.
- `add_to_fstab`, `setup_chroot_mount`: guard fstab backup overwrite; use `mountpoint -q` before mounting to skip when already mounted

**Templates:**
- `backup.tt`: `rm -f` instead of bare `rm`; guard authorized_keys append with `grep -qF` to prevent duplicate keys on redeploy
- `tpsgi.tt`: guard `git clone` with `.git` existence check; guard `ln -s` with `-L` check
- `nginxproxy.tt`: collapse two inline `systemctl restart nginx` calls into one deferred `queue_postrun_task`
- `fail2ban.tt`: defer `systemctl reload fail2ban` via `queue_postrun_task`
- `ufw.tt`: defer `ufw restart`, `setup-ufw-rules`, port-forward setup, and sendmail outbound rule via `queue_postrun_task`

## Testing

These are shell/make fragments — no test suite exists. Each change follows established patterns already merged (`.bak` guard, `grep -qF`, `queue_postrun_task`, `mountpoint -q`, `-L` for symlinks) from prior PRs in this series.